### PR TITLE
Linting and typing fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,12 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+uv.lock
+
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
@@ -160,3 +166,14 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# VSCode workspace-local settings
+#  May include useful settings for the project, but mostly it depends on the extensions enabled.
+#  Another option can be just ignoring .vscode/settings.json and sync some recommendations.
+.vscode

--- a/causalflows/conftest.py
+++ b/causalflows/conftest.py
@@ -1,11 +1,11 @@
 r"""Doctests configuration."""
 
-import causalflows
 import pytest
 import torch
 import zuko
-
 from torch.distributions import ExpTransform, Gamma
+
+import causalflows
 
 
 @pytest.fixture(autouse=True, scope="module")

--- a/causalflows/core.py
+++ b/causalflows/core.py
@@ -2,8 +2,6 @@ r"""Causal Normalizing Flow class."""
 
 __all__ = ['CausalFlow']
 
-from typing import Optional
-
 from torch import Tensor
 from zuko.flows import Flow
 
@@ -22,7 +20,7 @@ class CausalFlow(Flow):
         base: A lazy distribution.
     """
 
-    def forward(self, context: Optional[Tensor] = None) -> CausalNormalizingFlow:
+    def forward(self, context: Tensor | None = None) -> CausalNormalizingFlow:
         r"""
         Arguments:
             context: An input tensor representing the context of the (conditional) flow.

--- a/causalflows/core.py
+++ b/causalflows/core.py
@@ -2,10 +2,12 @@ r"""Causal Normalizing Flow class."""
 
 __all__ = ['CausalFlow']
 
-from .distributions import CausalNormalizingFlow
-from torch import Tensor
 from typing import Optional
+
+from torch import Tensor
 from zuko.flows import Flow
+
+from .distributions import CausalNormalizingFlow
 
 
 class CausalFlow(Flow):

--- a/causalflows/distributions.py
+++ b/causalflows/distributions.py
@@ -2,12 +2,12 @@ r"""Causal Normalizing Flow distribution."""
 
 __all__ = ['CausalNormalizingFlow']
 
-import torch
-
 from contextlib import contextmanager
+from typing import List
+
+import torch
 from torch import LongTensor, Size, Tensor
 from torch.distributions import Distribution, Transform
-from typing import List
 from zuko.distributions import NormalizingFlow
 
 empty_size = Size()

--- a/causalflows/flows.py
+++ b/causalflows/flows.py
@@ -3,11 +3,7 @@ r"""Wrappers for causal normalizing flows using standard architectures."""
 __all__ = ['CausalFlow', 'CausalMAF', 'CausalNAF', 'CausalNCSF', 'CausalNSF', 'CausalUNAF']
 
 from math import pi
-from typing import (
-    Any,
-    Dict,
-    Optional,
-)
+from typing import Any
 
 import torch
 from torch import BoolTensor, LongTensor, Size
@@ -69,11 +65,11 @@ class CausalMAF(CausalFlow):
         self,
         features: int,
         context: int = 0,
-        *args,
-        order: Optional[LongTensor] = None,
-        adjacency: Optional[BoolTensor] = None,
-        **kwargs,
-    ):
+        *_: Any,
+        order: LongTensor | None = None,
+        adjacency: BoolTensor | None = None,
+        **kwargs: Any,
+    ) -> None:
         assert (order is None) != (adjacency is None), (
             "One of `order` or `adjacency` must be specified."
         )
@@ -125,8 +121,8 @@ class CausalNSF(CausalMAF):
         features: int,
         context: int = 0,
         bins: int = 8,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         super().__init__(
             features=features,
             context=context,
@@ -162,8 +158,8 @@ class CausalNCSF(CausalMAF):
         features: int,
         context: int = 0,
         bins: int = 8,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         super().__init__(
             features=features,
             context=context,
@@ -211,12 +207,12 @@ class CausalNAF(CausalFlow):
         features: int,
         context: int = 0,
         signal: int = 16,
-        *args,
-        order: Optional[LongTensor] = None,
-        adjacency: Optional[BoolTensor] = None,
-        network: Optional[Dict[str, Any]] = None,
-        **kwargs,
-    ):
+        *_: Any,
+        order: LongTensor | None = None,
+        adjacency: BoolTensor | None = None,
+        network: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
         assert (order is None) != (adjacency is None), (
             "One of `order` or `adjacency` must be specified."
         )
@@ -275,12 +271,12 @@ class CausalUNAF(CausalFlow):
         features: int,
         context: int = 0,
         signal: int = 16,
-        *args,
-        order: Optional[LongTensor] = None,
-        adjacency: Optional[BoolTensor] = None,
-        network: Dict[str, Any] = None,
-        **kwargs,
-    ):
+        *_: Any,
+        order: LongTensor | None = None,
+        adjacency: BoolTensor | None = None,
+        network: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
         assert (order is None) != (adjacency is None), (
             "One of `order` or `adjacency` must be specified."
         )
@@ -294,7 +290,7 @@ class CausalUNAF(CausalFlow):
             order=order,
             adjacency=adjacency,
             univariate=UMNN(signal=signal, stack=features, **network),
-            shapes=[Size((signal,)), ()],
+            shapes=[Size((signal,)), Size()],
             **kwargs,
         )
 

--- a/causalflows/flows.py
+++ b/causalflows/flows.py
@@ -2,16 +2,15 @@ r"""Wrappers for causal normalizing flows using standard architectures."""
 
 __all__ = ['CausalFlow', 'CausalMAF', 'CausalNAF', 'CausalNCSF', 'CausalNSF', 'CausalUNAF']
 
-import torch
-
-from .core import CausalFlow
 from math import pi
-from torch import BoolTensor, LongTensor, Size
 from typing import (
     Any,
     Dict,
     Optional,
 )
+
+import torch
+from torch import BoolTensor, LongTensor, Size
 from zuko.distributions import BoxUniform, DiagNormal
 from zuko.flows import (
     MaskedAutoregressiveTransform,
@@ -20,6 +19,8 @@ from zuko.flows import (
 from zuko.flows.neural import MNN, UMNN
 from zuko.flows.spline import CircularRQSTransform
 from zuko.transforms import MonotonicRQSTransform
+
+from .core import CausalFlow
 
 
 class CausalMAF(CausalFlow):
@@ -73,9 +74,9 @@ class CausalMAF(CausalFlow):
         adjacency: Optional[BoolTensor] = None,
         **kwargs,
     ):
-        assert (order is None) != (
-            adjacency is None
-        ), "One of `order` or `adjacency` must be specified."
+        assert (order is None) != (adjacency is None), (
+            "One of `order` or `adjacency` must be specified."
+        )
 
         transform = MaskedAutoregressiveTransform(
             features=features,
@@ -216,9 +217,9 @@ class CausalNAF(CausalFlow):
         network: Optional[Dict[str, Any]] = None,
         **kwargs,
     ):
-        assert (order is None) != (
-            adjacency is None
-        ), "One of `order` or `adjacency` must be specified."
+        assert (order is None) != (adjacency is None), (
+            "One of `order` or `adjacency` must be specified."
+        )
 
         if network is None:
             network = {}
@@ -280,9 +281,9 @@ class CausalUNAF(CausalFlow):
         network: Dict[str, Any] = None,
         **kwargs,
     ):
-        assert (order is None) != (
-            adjacency is None
-        ), "One of `order` or `adjacency` must be specified."
+        assert (order is None) != (adjacency is None), (
+            "One of `order` or `adjacency` must be specified."
+        )
 
         if network is None:
             network = {}

--- a/causalflows/scms.py
+++ b/causalflows/scms.py
@@ -1,14 +1,15 @@
 r"""Helper class to create synthetic SCMs and pre-defined instances of SCMs ready to use."""
 
+from math import sqrt
+from typing import Union
+
 import torch
 import torch.nn.functional as F
-
-from .distributions import CausalNormalizingFlow
-from math import sqrt
 from torch import BoolTensor, LongTensor, Tensor
 from torch.distributions import Distribution, Independent, Normal, Transform, Uniform, constraints
-from typing import Union
 from zuko.distributions import NormalizingFlow
+
+from .distributions import CausalNormalizingFlow
 
 
 class CausalEquations(Transform):

--- a/causalflows/scms.py
+++ b/causalflows/scms.py
@@ -1,7 +1,8 @@
 r"""Helper class to create synthetic SCMs and pre-defined instances of SCMs ready to use."""
 
+from collections.abc import Callable, Sequence
 from math import sqrt
-from typing import Union
+from typing import Union, cast
 
 import torch
 import torch.nn.functional as F
@@ -11,17 +12,32 @@ from zuko.distributions import NormalizingFlow
 
 from .distributions import CausalNormalizingFlow
 
+NTen2Ten = (  # TODO type statement
+    Callable[[Tensor], Tensor]
+    | Callable[[Tensor, Tensor], Tensor]
+    | Callable[[Tensor, Tensor, Tensor], Tensor]
+    | Callable[[Tensor, Tensor, Tensor, Tensor], Tensor]
+    | Callable[[Tensor, Tensor, Tensor, Tensor, Tensor], Tensor]
+)
+Tens2Ten = Callable[[*tuple[Tensor, ...]], Tensor]  # TODO type statement
+
 
 class CausalEquations(Transform):
     domain = constraints.unit_interval
     codomain = constraints.real
     bijective = True
 
-    def __init__(self, functions, inverses, derivatives=None):
+    def __init__(
+        self,
+        functions: Sequence[Tens2Ten | NTen2Ten],
+        inverses: Sequence[Tens2Ten | NTen2Ten],
+        derivatives: Sequence[Tens2Ten | NTen2Ten] | None = None,
+    ):
         super(CausalEquations, self).__init__(cache_size=0)
-        self.functions = functions
-        self.inverses = inverses
-        self.derivatives = derivatives
+        # Must use force cast because they are incompatible
+        self.functions: Sequence[Tens2Ten] = cast(Sequence[Tens2Ten], functions)
+        self.inverses: Sequence[Tens2Ten] = cast(Sequence[Tens2Ten], inverses)
+        self.derivatives: Sequence[Tens2Ten] | None = cast(Sequence[Tens2Ten] | None, derivatives)
 
         self._interventions = dict()
 
@@ -124,13 +140,13 @@ class SCM(CausalNormalizingFlow):
 
 class Triangle(CausalEquations):
     def __init__(self, eq_type: str):
-        if eq_type == 'linear':
-            functions = [
+        if eq_type == "linear":
+            functions: list[NTen2Ten] = [
                 lambda u1: u1 + 1.0,
                 lambda x1, u2: 10 * x1 - u2,
                 lambda x1, x2, u3: 0.5 * x2 + x1 + 1.0 * u3,
             ]
-            inverses = [
+            inverses: list[NTen2Ten] = [
                 lambda x1: x1 - 1.0,
                 lambda x1, x2: (10 * x1 - x2),
                 lambda x1, x2, x3: (x3 - 0.5 * x2 - x1) / 1.0,
@@ -176,31 +192,31 @@ class Simpson(CausalEquations):
     def __init__(self, eq_type: str):
         s = torch.nn.functional.softplus
 
-        if eq_type == 'non-linear':
-            functions = [
+        if eq_type == "non-linear":
+            functions: list[NTen2Ten] = [
                 lambda u1: u1,
                 lambda x1, u2: s(1.0 - x1) + sqrt(3 / 20.0) * u2,
                 lambda x1, x2, u3: torch.tanh(2 * x2) + 3 / 2 * x1 - 1 + torch.tanh(u3),
-                lambda x1, x2, x3, u4: (x3 - 4.0) / 5.0 + 3 + 1 / sqrt(10) * u4,
+                lambda _1, _2, x3, u4: (x3 - 4.0) / 5.0 + 3 + 1 / sqrt(10) * u4,
             ]
-            inverses = [
+            inverses: list[NTen2Ten] = [
                 lambda x1: x1,
                 lambda x1, x2: 1 / sqrt(3 / 20.0) * (x2 - s(1.0 - x1)),
                 lambda x1, x2, x3: torch.atanh(x3 - torch.tanh(2 * x2) - 3 / 2 * x1 + 1),
-                lambda _, __, x3, x4: sqrt(10) * (x4 - (x3 - 4.0) / 5.0 - 3),
+                lambda _1, _2, x3, x4: sqrt(10) * (x4 - (x3 - 4.0) / 5.0 - 3),
             ]
         elif eq_type == 'sym-prod':
             functions = [
                 lambda u1: u1,
                 lambda x1, u2: 2 * torch.tanh(2 * x1) + 1 / sqrt(10) * u2,
                 lambda x1, x2, u3: 1 / 2 * x1 * x2 + 1 / sqrt(2) * u3,
-                lambda x1, x2, x3, u4: torch.tanh(3 / 2 * x1) + sqrt(3 / 10) * u4,
+                lambda x1, _2, _3, u4: torch.tanh(3 / 2 * x1) + sqrt(3 / 10) * u4,
             ]
             inverses = [
                 lambda x1: x1,
                 lambda x1, x2: sqrt(10) * (x2 - 2 * torch.tanh(2 * x1)),
                 lambda x1, x2, x3: sqrt(2) * (x3 - 1 / 2 * x1 * x2),
-                lambda x1, x2, x3, x4: 1 / sqrt(3 / 10) * (x4 - torch.tanh(3 / 2 * x1)),
+                lambda x1, _2, _3, x4: 1 / sqrt(3 / 10) * (x4 - torch.tanh(3 / 2 * x1)),
             ]
         else:
             raise ValueError(f'Equation type {eq_type} not supported.')
@@ -246,11 +262,12 @@ class LargeBackdoor(CausalEquations):
         def cdf_laplace(loc, scale, value):
             return 0.5 - 0.5 * (value - loc).sign() * torch.expm1(-(value - loc).abs() / scale)
 
-        if eq_type == 'non-linear':
-            functions = [
-                lambda u1: F.softplus(1.8 * u1) - 1,  # x1
-                lambda x1, u2: 0.25 * u2 + layer(x1, torch.zeros_like(u2)) * 1.5,  # x2
-                lambda x1, x2, u3: layer(x1, u3),  # x3
+        if eq_type == "non-linear":
+            functions: list[Tens2Ten] = [
+                lambda *args: F.softplus(1.8 * args[-1]) - 1,  # x1
+                lambda *args: 0.25 * args[-1]
+                + layer(args[0], torch.zeros_like(args[-1])) * 1.5,  # x2
+                lambda *args: layer(args[0], args[-1]),  # x3
                 lambda *args: layer(args[1], args[-1]),  # x4
                 lambda *args: layer(args[2], args[-1]),  # x5
                 lambda *args: layer(args[3], args[-1]),  # x6
@@ -260,7 +277,7 @@ class LargeBackdoor(CausalEquations):
                     -F.softplus((args[6] * 1.3 + args[7]) / 3 + 1) + 2, 0.6, args[-1]
                 ),  # x9
             ]
-            inverses = [
+            inverses: list[Tens2Ten] = [
                 lambda *args: inv_softplus(args[-1] + 1) / 1.8,  # u1
                 lambda *args: 4
                 * (-layer(args[0], torch.zeros_like(args[-1])) * 1.5 + args[-1]),  # u2
@@ -297,31 +314,31 @@ class LargeBackdoor(CausalEquations):
 
 class Fork(CausalEquations):
     def __init__(self, eq_type: str):
-        if eq_type == 'linear':
-            functions = [
+        if eq_type == "linear":
+            functions: list[NTen2Ten] = [
                 lambda u1: u1,
-                lambda _, u2: 2.0 - u2,
+                lambda _1, u2: 2.0 - u2,
                 lambda x1, x2, u3: 0.25 * x2 - 1.5 * x1 + 0.5 * u3,
-                lambda _, __, x3, u4: 1.0 * x3 + 0.25 * u4,
+                lambda _1, _2, x3, u4: 1.0 * x3 + 0.25 * u4,
             ]
-            inverses = [
+            inverses: list[NTen2Ten] = [
                 lambda x1: x1,
-                lambda _, x2: 2.0 - x2,
+                lambda _1, x2: 2.0 - x2,
                 lambda x1, x2, x3: (x3 - 0.25 * x2 + 1.5 * x1) / 0.5,
-                lambda _, __, x3, x4: (x4 - 1.0 * x3) / 0.25,
+                lambda _1, _2, x3, x4: (x4 - 1.0 * x3) / 0.25,
             ]
         elif eq_type == 'non-linear':
             functions = [
                 lambda u1: u1,
-                lambda x1, u2: u2,
+                lambda _1, u2: u2,
                 lambda x1, x2, u3: 4.0 / (1 + torch.exp(-x1 - x2)) - x2**2 + u3 / 2.0,
-                lambda x1, x2, x3, u4: 20.0 / (1 + torch.exp(x3**2 / 2 - x3)) + u4,
+                lambda _1, _2, x3, u4: 20.0 / (1 + torch.exp(x3**2 / 2 - x3)) + u4,
             ]
             inverses = [
                 lambda x1: x1,
-                lambda x1, x2: x2,
+                lambda _1, x2: x2,
                 lambda x1, x2, x3: 2.0 * (x3 - 4.0 / (1 + torch.exp(-x1 - x2)) + x2**2),
-                lambda x1, x2, x3, x4: x4 - 20.0 / (1 + torch.exp(x3**2 / 2 - x3)),
+                lambda _1, _2, x3, x4: x4 - 20.0 / (1 + torch.exp(x3**2 / 2 - x3)),
             ]
         else:
             raise ValueError(f'Equation type {eq_type} not supported.')
@@ -341,18 +358,18 @@ class Fork(CausalEquations):
 
 class Diamond(CausalEquations):
     def __init__(self, eq_type: str):
-        if eq_type == 'non-linear':
-            functions = [
+        if eq_type == "non-linear":
+            functions: list[NTen2Ten] = [
                 lambda u1: u1,
                 lambda x1, u2: x1**2 + u2 / 2,
                 lambda x1, x2, u3: x2**2 - 2.0 / (1 + torch.exp(-x1)) + u3 / 2.0,
-                lambda x1, x2, x3, u4: x3 / ((x2 + 2.0).abs() + x3 + 0.5) + u4 / 10.0,
+                lambda _1, x2, x3, u4: x3 / ((x2 + 2.0).abs() + x3 + 0.5) + u4 / 10.0,
             ]
-            inverses = [
+            inverses: list[NTen2Ten] = [
                 lambda x1: x1,
                 lambda x1, x2: 2 * (x2 - x1**2),
                 lambda x1, x2, x3: (x3 - x2**2 + 2.0 / (1 + torch.exp(-x1))) * 2.0,
-                lambda x1, x2, x3, x4: 10 * (x4 - x3 / ((x2 + 2.0).abs() + x3 + 0.5)),
+                lambda _1, x2, x3, x4: 10 * (x4 - x3 / ((x2 + 2.0).abs() + x3 + 0.5)),
             ]
         else:
             raise ValueError(f'Equation type {eq_type} not supported.')
@@ -372,15 +389,15 @@ class Diamond(CausalEquations):
 
 class Collider(CausalEquations):
     def __init__(self, eq_type: str):
-        if eq_type == 'linear':
-            functions = [
+        if eq_type == "linear":
+            functions: list[NTen2Ten] = [
                 lambda u1: u1,
-                lambda _, u2: 2.0 - u2,
+                lambda _1, u2: 2.0 - u2,
                 lambda x1, x2, u3: 0.25 * x2 - 0.5 * x1 + 0.5 * u3,
             ]
-            inverses = [
+            inverses: list[NTen2Ten] = [
                 lambda x1: x1,
-                lambda _, x2: 2.0 - x2,
+                lambda _1, x2: 2.0 - x2,
                 lambda x1, x2, x3: (x3 - 0.25 * x2 + 0.5 * x1) / 0.5,
             ]
         else:
@@ -400,49 +417,49 @@ class Collider(CausalEquations):
 
 class Chain3(CausalEquations):
     def __init__(self, eq_type: str):
-        if eq_type == 'linear':
-            functions = [
+        if eq_type == "linear":
+            functions: list[NTen2Ten] = [
                 lambda u1: u1,
                 lambda x1, u2: 10 * x1 - u2,
-                lambda x1, x2, u3: 0.25 * x2 + 2 * u3,
+                lambda _1, x2, u3: 0.25 * x2 + 2 * u3,
             ]
-            inverses = [
+            inverses: list[NTen2Ten] = [
                 lambda x1: x1,
                 lambda x1, x2: (10 * x1 - x2),
-                lambda x1, x2, x3: (x3 - 0.25 * x2) / 2,
+                lambda _1, x2, x3: (x3 - 0.25 * x2) / 2,
             ]
         elif eq_type == 'non-linear':
             functions = [
                 lambda u1: u1,
                 lambda x1, u2: torch.exp(x1 / 2.0) + u2 / 4.0,
-                lambda x1, x2, u3: (x2 - 5) ** 3 / 15.0 + u3,
+                lambda _1, x2, u3: (x2 - 5) ** 3 / 15.0 + u3,
             ]
             inverses = [
                 lambda x1: x1,
                 lambda x1, x2: 4.0 * (x2 - torch.exp(x1 / 2.0)),
-                lambda x1, x2, x3: x3 - (x2 - 5) ** 3 / 15.0,
+                lambda _1, x2, x3: x3 - (x2 - 5) ** 3 / 15.0,
             ]
         elif eq_type == 'non-linear-2':
             functions = [
                 lambda u1: torch.sigmoid(u1),
                 lambda x1, u2: 10 * x1**0.5 - u2,
-                lambda x1, x2, u3: 0.25 * x2 + 2 * u3,
+                lambda _1, x2, u3: 0.25 * x2 + 2 * u3,
             ]
             inverses = [
                 lambda x1: torch.logit(x1),
                 lambda x1, x2: (10 * x1**0.5 - x2),
-                lambda x1, x2, x3: (x3 - 0.25 * x2) / 2,
+                lambda _1, x2, x3: (x3 - 0.25 * x2) / 2,
             ]
         elif eq_type == 'non-linear-3':
             functions = [
                 lambda u1: u1,
                 lambda x1, u2: 1 * x1**2.0 - u2,
-                lambda x1, x2, u3: 0.25 * x2 + 2 * u3,
+                lambda _1, x2, u3: 0.25 * x2 + 2 * u3,
             ]
             inverses = [
                 lambda x1: x1,
                 lambda x1, x2: (1 * x1**2.0 - x2),
-                lambda x1, x2, x3: (x3 - 0.25 * x2) / 2,
+                lambda _1, x2, x3: (x3 - 0.25 * x2) / 2,
             ]
         else:
             raise ValueError(f'Equation type {eq_type} not supported.')
@@ -461,14 +478,14 @@ class Chain3(CausalEquations):
 
 class Chain4(CausalEquations):
     def __init__(self, eq_type: str):
-        if eq_type == 'linear':
-            functions = [
+        if eq_type == "linear":
+            functions: list[NTen2Ten] = [
                 lambda u1: u1,
                 lambda x1, u2: 5 * x1 - u2,
                 lambda _1, x2, u3: -0.5 * x2 - 1.5 * u3,
                 lambda _1, _2, x3, u4: x3 + u4,
             ]
-            inverses = [
+            inverses: list[NTen2Ten] = [
                 lambda x1: x1,
                 lambda x1, x2: (5 * x1 - x2),
                 lambda _1, x2, x3: (-0.5 * x2 - x3) / 1.5,
@@ -492,15 +509,15 @@ class Chain4(CausalEquations):
 
 class Chain5(CausalEquations):
     def __init__(self, eq_type: str):
-        if eq_type == 'linear':
-            functions = [
+        if eq_type == "linear":
+            functions: list[NTen2Ten] = [
                 lambda u1: u1,
                 lambda x1, u2: 10 * x1 - u2,
                 lambda _1, x2, u3: 0.25 * x2 + 2 * u3,
                 lambda _1, _2, x3, u4: x3 + u4,
                 lambda _1, _2, _3, x4, u5: -x4 + u5,
             ]
-            inverses = [
+            inverses: list[NTen2Ten] = [
                 lambda x1: x1,
                 lambda x1, x2: (10 * x1 - x2),
                 lambda _1, x2, x3: (x3 - 0.25 * x2) / 2,

--- a/causalflows/scms.py
+++ b/causalflows/scms.py
@@ -164,12 +164,12 @@ class Triangle(CausalEquations):
         super().__init__(functions, inverses)
 
     @property
-    def adjacency(self):
-        return torch.tensor((
+    def adjacency(self) -> BoolTensor:
+        return BoolTensor((
             (1, 0, 0),
             (1, 1, 0),
             (1, 1, 1),
-        )).bool()
+        ))
 
 
 class Simpson(CausalEquations):
@@ -209,21 +209,21 @@ class Simpson(CausalEquations):
         super().__init__(functions, inverses)
 
     @property
-    def adjacency(self):
-        if self.eq_type == 'non-linear':
-            return torch.tensor((
+    def adjacency(self) -> BoolTensor:
+        if self.eq_type == "non-linear":
+            return BoolTensor((
                 (1, 0, 0, 0),
                 (1, 1, 0, 0),
                 (1, 1, 1, 0),
                 (0, 0, 1, 1),
-            )).bool()
-        elif self.eq_type == 'sym-prod':
-            return torch.tensor((
+            ))
+        elif self.eq_type == "sym-prod":
+            return BoolTensor((
                 (1, 0, 0, 0),
                 (1, 1, 0, 0),
                 (1, 1, 1, 0),
                 (1, 0, 0, 1),
-            )).bool()
+            ))
 
         raise ValueError(f'Equation type {self.eq_type} not supported.')
 
@@ -281,8 +281,8 @@ class LargeBackdoor(CausalEquations):
         super().__init__(functions, inverses)
 
     @property
-    def adjacency(self):
-        return torch.tensor([
+    def adjacency(self) -> BoolTensor:
+        return BoolTensor((
             (1, 0, 0, 0, 0, 0, 0, 0, 0),
             (1, 1, 0, 0, 0, 0, 0, 0, 0),
             (1, 0, 1, 0, 0, 0, 0, 0, 0),
@@ -292,7 +292,7 @@ class LargeBackdoor(CausalEquations):
             (0, 0, 0, 0, 1, 0, 1, 0, 0),
             (0, 0, 0, 0, 0, 1, 0, 1, 0),
             (0, 0, 0, 0, 0, 0, 1, 1, 1),
-        ]).bool()
+        ))
 
 
 class Fork(CausalEquations):
@@ -330,13 +330,13 @@ class Fork(CausalEquations):
         super().__init__(functions, inverses)
 
     @property
-    def adjacency(self):
-        return torch.tensor((
+    def adjacency(self) -> BoolTensor:
+        return BoolTensor((
             (1, 0, 0, 0),
             (0, 1, 0, 0),
             (1, 1, 1, 0),
             (0, 0, 1, 1),
-        )).bool()
+        ))
 
 
 class Diamond(CausalEquations):
@@ -361,13 +361,13 @@ class Diamond(CausalEquations):
         super().__init__(functions, inverses)
 
     @property
-    def adjacency(self):
-        return torch.tensor((
+    def adjacency(self) -> BoolTensor:
+        return BoolTensor((
             (1, 0, 0, 0),
             (1, 1, 0, 0),
             (1, 1, 1, 0),
             (0, 1, 1, 1),
-        )).bool()
+        ))
 
 
 class Collider(CausalEquations):
@@ -390,12 +390,12 @@ class Collider(CausalEquations):
         super().__init__(functions, inverses)
 
     @property
-    def adjacency(self):
-        return torch.tensor((
+    def adjacency(self) -> BoolTensor:
+        return BoolTensor((
             (1, 0, 0),
             (0, 1, 0),
             (1, 1, 1),
-        )).bool()
+        ))
 
 
 class Chain3(CausalEquations):
@@ -451,12 +451,12 @@ class Chain3(CausalEquations):
         super().__init__(functions, inverses)
 
     @property
-    def adjacency(self):
-        return torch.tensor((
+    def adjacency(self) -> BoolTensor:
+        return BoolTensor((
             (1, 0, 0),
             (1, 1, 0),
             (0, 1, 1),
-        )).bool()
+        ))
 
 
 class Chain4(CausalEquations):
@@ -481,13 +481,13 @@ class Chain4(CausalEquations):
         super().__init__(functions, inverses)
 
     @property
-    def adjacency(self):
-        return torch.tensor((
+    def adjacency(self) -> BoolTensor:
+        return BoolTensor((
             (1, 0, 0, 0),
             (1, 1, 0, 0),
             (0, 1, 1, 0),
             (0, 0, 1, 1),
-        )).bool()
+        ))
 
 
 class Chain5(CausalEquations):
@@ -514,11 +514,11 @@ class Chain5(CausalEquations):
         super().__init__(functions, inverses)
 
     @property
-    def adjacency(self):
-        return torch.tensor((
+    def adjacency(self) -> BoolTensor:
+        return BoolTensor((
             (1, 0, 0, 0, 0),
             (1, 1, 0, 0, 0),
             (0, 1, 1, 0, 0),
             (0, 0, 1, 1, 0),
             (0, 0, 0, 1, 1),
-        )).bool()
+        ))

--- a/causalflows/scms.py
+++ b/causalflows/scms.py
@@ -6,7 +6,7 @@ from typing import Self, cast
 
 import torch
 import torch.nn.functional as F
-from torch import BoolTensor, LongTensor, Tensor
+from torch import BoolTensor, Tensor
 from torch.distributions import Distribution, Independent, Normal, Transform, Uniform, constraints
 
 from .distributions import CausalNormalizingFlow
@@ -122,12 +122,12 @@ class SCM(CausalNormalizingFlow):
         assert (adj.shape[0] == adj.shape[1]) and (len(adj.shape) == 2)
         return adj
 
-    def _start_intervention(self, index: LongTensor, value: Tensor) -> Self:
-        self.equations.add_intervention(index, value)  # ??????????
+    def _start_intervention(self, index: int, value: Tensor | float | Sequence[float]) -> Self:
+        self.equations.add_intervention(index, torch.as_tensor(value))
         return self
 
-    def _stop_intervention(self, index: LongTensor) -> None:
-        self.equations.remove_intervention(index)  # ??????????
+    def _stop_intervention(self, index: int) -> None:
+        self.equations.remove_intervention(index)
 
 
 ####

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,12 +1,13 @@
 # Configuration file for the Sphinx documentation builder
 
-import causalflows
 import glob
 import importlib
 import inspect
 import pathlib
 import re
 import subprocess
+
+import causalflows
 
 ## Project
 

--- a/pre-commit.yml
+++ b/pre-commit.yml
@@ -1,12 +1,12 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.8
+  rev: v0.9.10
   hooks:
     - id: ruff
     - id: ruff-format
       args: [--diff]
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v5.0.0
   hooks:
     - id: check-added-large-files
     - id: check-merge-conflict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ keywords = [
   "causal inference",
 ]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
   "zuko>=1.3.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 ]
 
 
-[dependency-groups]
+[project.optional-dependencies]
 dev = [
   "pre-commit",
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,6 @@ preview = true
 "*.ipynb" = ["B007"]
 
 [tool.ruff.lint.isort]
-lines-between-types = 1
-no-sections = true
 relative-imports-order = "closest-to-furthest"
 
 [tool.ruff.format]

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
   jobs:
     post_install:
       - pip install -U setuptools

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1,12 +1,13 @@
 r"""Tests for the zuko.flows module."""
 
-import pytest
-import torch
-
-from causalflows.flows import *
 from math import pi
 from pathlib import Path
+
+import pytest
+import torch
 from torch import randn
+
+from causalflows.flows import *
 
 
 # @pytest.mark.parametrize("F", [CausalMAF, CausalNSF, CausalNAF, CausalUNAF, CausalNCSF])


### PR DESCRIPTION
- Changes isort setting to split sections
- Fixes typing to satisfy (mostly) mypy/pyright
  - Update python requirement to 3.10 to use new typing syntax
- Adopts some suggestions from pylint

1 behavior change:
`IntervenedTransform` now caches args in `__init__`